### PR TITLE
Fixed logfile name

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -521,7 +521,7 @@ def runRSpecTest(testFilePath, dockerArgs, credentials) {
                   cd tests/rspec
 
                   # Directing test output both to stdout as well as a log file
-                  rspec ${testFilePath} --format RspecTap::Formatter --format RspecTap::Formatter --out ../../templogfiles/format=tap.log
+                  rspec ${testFilePath} --format RspecTap::Formatter --format RspecTap::Formatter --out ../../templogfiles/tap.log
                 """
               }
             }
@@ -566,7 +566,7 @@ def runRSpecTestBareMetal(testFilePath, credentials) {
               rbenv install -s
               gem install bundler
               bundler install
-              bundler exec rspec ${testFilePath} --format RspecTap::Formatter --format RspecTap::Formatter --out ../../templogfiles/format=tap.log
+              bundler exec rspec ${testFilePath} --format RspecTap::Formatter --format RspecTap::Formatter --out ../../templogfiles/tap.log
               """
             }
           }


### PR DESCRIPTION
This calls the Tap output file by a "regular" name so that the shipping script has full control over the field name used in ES.